### PR TITLE
Make MediaDataChange show context

### DIFF
--- a/src/lib/components/notifications/MediaNotification.svelte
+++ b/src/lib/components/notifications/MediaNotification.svelte
@@ -24,7 +24,7 @@
       {notification.contexts[1]}
       <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
       {notification.contexts[2]}
-    {:else if notification.type === NotificationType.RELATED_MEDIA_ADDITION}
+    {:else}
       <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
       {notification.context}
     {/if}


### PR DESCRIPTION
Previously the MEDIA_DATA_CHANGE notification type was not displaying context in it's notification as there was no condition for it.
This PR will default both the RELATED_MEDIA_ADDTION and MEDIA_DATA_CHANGE notification types to showing Title + Notification Context

(Doesn't look like it'll break anything at a glance)