### PR TITLE
Fix MediaList queryStore not refreshing correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tailwindcss/line-clamp": "0.4.2",
         "@tailwindcss/typography": "0.5.7",
         "@urql/exchange-graphcache": "5.0.4",
-        "@urql/svelte": "3.0.1",
+        "@urql/svelte": "^4.0.4",
         "graphql": "16.6.0",
         "graphql-tag": "2.12.6",
         "history": "5.3.0",
@@ -24,7 +24,7 @@
         "svelte-lazy": "1.1.0",
         "svelte-navigator": "3.2.2",
         "svelte-previous": "2.1.1",
-        "svelte-ripple": "^0.1.1",
+        "svelte-ripple": "0.1.1",
         "timeago.js": "4.0.2",
         "webext-storage-cache": "5.1.0",
         "webextension-polyfill": "0.10.0"
@@ -53,6 +53,19 @@
         "vite": "3.2.2",
         "web-ext": "7.3.1",
         "yazl": "2.5.1"
+      }
+    },
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
+      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2162,6 +2175,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
       "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "dev": true,
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
@@ -3078,15 +3092,12 @@
       }
     },
     "node_modules/@urql/core": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.0.5.tgz",
-      "integrity": "sha512-6/1HG+WEAcPs+hXSFnxWBTWkNUwa8dj2cHysWokMaFIbAioGtUaSdxp2q9FDMtWAIGdc640NFSt2B8itGLdoAA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.3.tgz",
+      "integrity": "sha512-Wapa58olpEJtZzSEuZNDxzBxmOmHuivG6Hb/QPc6HjHfCJ6f36gnlWc9a9TsC8Vddle+6PsS6+quMMTuj+bj7A==",
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "wonka": "^6.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "@0no-co/graphql.web": "^1.0.1",
+        "wonka": "^6.3.2"
       }
     },
     "node_modules/@urql/exchange-graphcache": {
@@ -3111,16 +3122,15 @@
       }
     },
     "node_modules/@urql/svelte": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@urql/svelte/-/svelte-3.0.1.tgz",
-      "integrity": "sha512-O5WsLIVl6fWk9duQm2jp3vvVcAqOtru3LEwKAYaM2v6e/tYYxJGYrzNFe3hPkP6H7h0bmOMZBdjGbhGBbF98yA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@urql/svelte/-/svelte-4.0.4.tgz",
+      "integrity": "sha512-HYz9dHdqEcs9d82WWczQ3XG+zuup3TS01H+txaij/QfQ+KHjrlrn0EkOHQQd1S+H8+nFjFU2x9+HE3+3fuwL1A==",
       "dependencies": {
-        "@urql/core": "^3.0.0",
-        "wonka": "^6.0.0"
+        "@urql/core": "^4.1.0",
+        "wonka": "^6.3.2"
       },
       "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-        "svelte": "^3.0.0"
+        "svelte": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@whatwg-node/fetch": {
@@ -11560,9 +11570,9 @@
       "dev": true
     },
     "node_modules/wonka": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.1.tgz",
-      "integrity": "sha512-shBtyZ0KFvUadtnDGlTRA4mF4pgcRoyZKikdputKhmShoXWcZDvlg6CUw6Jx9nTL7Ub8QUJoIarPpxdlosg9cw=="
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
+      "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -11779,6 +11789,12 @@
     }
   },
   "dependencies": {
+    "@0no-co/graphql.web": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
+      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "requires": {}
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -13398,6 +13414,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
       "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "dev": true,
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -14001,12 +14018,12 @@
       }
     },
     "@urql/core": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.0.5.tgz",
-      "integrity": "sha512-6/1HG+WEAcPs+hXSFnxWBTWkNUwa8dj2cHysWokMaFIbAioGtUaSdxp2q9FDMtWAIGdc640NFSt2B8itGLdoAA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.3.tgz",
+      "integrity": "sha512-Wapa58olpEJtZzSEuZNDxzBxmOmHuivG6Hb/QPc6HjHfCJ6f36gnlWc9a9TsC8Vddle+6PsS6+quMMTuj+bj7A==",
       "requires": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "wonka": "^6.0.0"
+        "@0no-co/graphql.web": "^1.0.1",
+        "wonka": "^6.3.2"
       }
     },
     "@urql/exchange-graphcache": {
@@ -14026,12 +14043,12 @@
       "requires": {}
     },
     "@urql/svelte": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@urql/svelte/-/svelte-3.0.1.tgz",
-      "integrity": "sha512-O5WsLIVl6fWk9duQm2jp3vvVcAqOtru3LEwKAYaM2v6e/tYYxJGYrzNFe3hPkP6H7h0bmOMZBdjGbhGBbF98yA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@urql/svelte/-/svelte-4.0.4.tgz",
+      "integrity": "sha512-HYz9dHdqEcs9d82WWczQ3XG+zuup3TS01H+txaij/QfQ+KHjrlrn0EkOHQQd1S+H8+nFjFU2x9+HE3+3fuwL1A==",
       "requires": {
-        "@urql/core": "^3.0.0",
-        "wonka": "^6.0.0"
+        "@urql/core": "^4.1.0",
+        "wonka": "^6.3.2"
       }
     },
     "@whatwg-node/fetch": {
@@ -20154,9 +20171,9 @@
       "dev": true
     },
     "wonka": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.1.tgz",
-      "integrity": "sha512-shBtyZ0KFvUadtnDGlTRA4mF4pgcRoyZKikdputKhmShoXWcZDvlg6CUw6Jx9nTL7Ub8QUJoIarPpxdlosg9cw=="
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
+      "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tailwindcss/line-clamp": "0.4.2",
     "@tailwindcss/typography": "0.5.7",
     "@urql/exchange-graphcache": "5.0.4",
-    "@urql/svelte": "3.0.1",
+    "@urql/svelte": "^4.0.4",
     "graphql": "16.6.0",
     "graphql-tag": "2.12.6",
     "history": "5.3.0",

--- a/src/entries/popup/routes/New.svelte
+++ b/src/entries/popup/routes/New.svelte
@@ -43,7 +43,7 @@
     <Section raise={false}>
       <a slot="title" class="hover:text-accent transition-colors" href="https://anilist.co/search/anime/new" target="_blank">New Anime</a>
       <div class="grid gap-x-2 gap-y-4 {$extensionConfig.theme.wide ? "grid-cols-6" : "grid-cols-4"}">
-        {#each $recentAnime.data.Page.media as media (media.id)}
+        {#each $recentAnime.data.Page.media || [] as media (media.id)}
           <MediaCard {media} />
         {/each}
       </div>
@@ -54,7 +54,7 @@
     <Section raise={false}>
       <a slot="title" class="hover:text-accent transition-colors" href="https://anilist.co/search/manga?format=MANGA&format=ONE_SHOT&sort=ID_DESC" target="_blank">New Manga</a>
       <div class="grid gap-x-2 gap-y-4 {$extensionConfig.theme.wide ? "grid-cols-6" : "grid-cols-4"}">
-        {#each $recentManga.data.Page.media as media (media.id)}
+        {#each $recentManga.data.Page.media || [] as media (media.id)}
           <MediaCard {media} />
         {/each}
       </div>
@@ -65,7 +65,7 @@
     <Section raise={false}>
       <a slot="title" class="hover:text-accent transition-colors" href="https://anilist.co/search/manga?format=NOVEL&sort=ID_DESC" target="_blank">New Light Novels</a>
       <div class="grid gap-x-2 gap-y-4 {$extensionConfig.theme.wide ? "grid-cols-6" : "grid-cols-4"}">
-        {#each $recentNovels.data.Page.media as media (media.id)}
+        {#each $recentNovels.data.Page.media || [] as media (media.id)}
           <MediaCard {media} />
         {/each}
       </div>


### PR DESCRIPTION
I've determined there may have been a bug in `@urql/svelte < 4.0.0` that has been causing issues with the `animeList` and `mangaList` `queryStores` from updating correctly when refreshing simultaneously.

Updating the dependency to the latest version seems to have solved this issue. (should close #74 )

Additionally, the newer version seems to have caused an issue with the previously working "What's New" page and I've added a default empty array to the affected each blocks so that any issues with rendering will be resolved while the query is still processing.