### PR TITLE
Fix notifications tab from erroring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animouto",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "animouto",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "1.5.3",

--- a/src/lib/components/notifications/MediaNotification.svelte
+++ b/src/lib/components/notifications/MediaNotification.svelte
@@ -4,14 +4,12 @@
   import { hexToRgb } from "$lib/util";
   import NotificationContainer from "./NotificationContainer.svelte";
 
-  export let notification: 
-  | (Pick<AiringNotification | RelatedMediaAdditionNotification | MediaDataChangeNotification, "createdAt" | "type"> & {
+  export let notification: Pick<AiringNotification | RelatedMediaAdditionNotification | MediaDataChangeNotification, "createdAt" | "type"> & {
     context?: string,
     contexts?: string[],
     episode?: number,
     media: Pick<MediaFragment, "id" | "title" | "img">,
-  })
-  | null;
+  };
   export let unread = false;
 </script>
 
@@ -22,14 +20,14 @@
     </Link>
     <Link to="/media/{notification.media.id}" class="line-clamp-3 mr-6 flex-1" --color-variable={hexToRgb(notification.media.img.color) || "--color-accent"}>
       {#if notification.type === NotificationType.AIRING}
-        {notification.contexts[0] || ""}
-        {notification.episode || ""}
-        {notification.contexts[1] || ""}
-        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred || ""}</span>
-        {notification.contexts[2] || ""}
+        {notification.contexts[0]}
+        {notification.episode}
+        {notification.contexts[1]}
+        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
+        {notification.contexts[2]}
       {:else}
-        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred || ""}</span>
-        {notification.context || ""}
+        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
+        {notification.context}
       {/if}
     </Link>
   </NotificationContainer>

--- a/src/lib/components/notifications/MediaNotification.svelte
+++ b/src/lib/components/notifications/MediaNotification.svelte
@@ -1,32 +1,73 @@
 <script lang="ts">
-  import { Link } from "svelte-navigator";
-  import { NotificationType, type MediaFragment, type AiringNotification, type RelatedMediaAdditionNotification, type MediaDataChangeNotification } from "@anilist/graphql";
-  import { hexToRgb } from "$lib/util";
-  import NotificationContainer from "./NotificationContainer.svelte";
+	import { Link } from "svelte-navigator";
+	import {
+		NotificationType,
+		type MediaFragment,
+		type AiringNotification,
+		type RelatedMediaAdditionNotification,
+		type MediaDataChangeNotification,
+	} from "@anilist/graphql";
+	import { hexToRgb } from "$lib/util";
+	import NotificationContainer from "./NotificationContainer.svelte";
 
-  export let notification: Pick<AiringNotification | RelatedMediaAdditionNotification | MediaDataChangeNotification, "createdAt" | "type"> & {
-    context?: string,
-    contexts?: string[],
-    episode?: number,
-    media: Pick<MediaFragment, "id" | "title" | "img">,
-  };
-  export let unread = false;
+	export let notification: Pick<
+		| AiringNotification
+		| RelatedMediaAdditionNotification
+		| MediaDataChangeNotification,
+		"createdAt" | "type"
+	> & {
+		context?: string;
+		contexts?: string[];
+		episode?: number;
+		media: Pick<MediaFragment, "id" | "title" | "img">;
+	};
+	export let unread = false;
+
+	let frozenId: number | null = null;
+	$: if (notification?.media && frozenId === null) {
+		frozenId = notification.media.id;
+	}
 </script>
 
 <NotificationContainer {unread} createdAt={notification.createdAt}>
-  <Link to="/media/{notification.media.id}" class="flex-none">
-    <img src={notification.media.img.large} alt="Key visual" class="w-12 mr-4 object-center object-cover aspect-[3/4]" />
-  </Link>
-  <Link to="/media/{notification.media.id}" class="line-clamp-3 mr-6 flex-1" --color-variable={hexToRgb(notification.media.img.color) || "--color-accent"}>
-    {#if notification.type === NotificationType.AIRING}
-      {notification.contexts[0]}
-      {notification.episode}
-      {notification.contexts[1]}
-      <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
-      {notification.contexts[2]}
-    {:else}
-      <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
-      {notification.context}
-    {/if}
-  </Link>
+	{#if frozenId !== null}
+		<Link to={`/media/${frozenId}`} class="flex-none">
+			<img
+				src={notification.media.img?.large || "/placeholder.png"}
+				alt={notification.media.title?.userPreferred || "Media"}
+				class="w-12 mr-4 object-center object-cover aspect-[3/4]"
+			/>
+		</Link>
+
+		<Link
+			to={`/media/${frozenId}`}
+			class="line-clamp-3 mr-6 flex-1"
+			style="--color-variable: {hexToRgb(notification.media.img?.color) ||
+				'var(--color-accent)'}"
+		>
+			{#if notification.type === NotificationType.AIRING}
+				{notification.contexts?.[0] || ""}
+				{notification.episode ?? ""}
+				{notification.contexts?.[1] || ""}
+				<span class="font-medium hover:text-variable transition-colors">
+					{notification.media.title?.userPreferred || "Unknown Title"}
+				</span>
+				{notification.contexts?.[2] || ""}
+			{:else}
+				<span class="font-medium hover:text-variable transition-colors">
+					{notification.media.title?.userPreferred || "Unknown Title"}
+				</span>
+				{notification.context || ""}
+			{/if}
+		</Link>
+	{:else}
+		<div class="flex items-center space-x-4 opacity-50 cursor-not-allowed">
+			<div class="w-12 h-16 bg-gray-200 rounded-md"></div>
+
+			<div class="flex-1 space-y-1">
+				<div class="h-4 bg-gray-200 rounded w-3/4"></div>
+				<div class="h-3 bg-gray-200 rounded w-1/2"></div>
+			</div>
+		</div>
+	{/if}
 </NotificationContainer>

--- a/src/lib/components/notifications/MediaNotification.svelte
+++ b/src/lib/components/notifications/MediaNotification.svelte
@@ -1,73 +1,36 @@
 <script lang="ts">
-	import { Link } from "svelte-navigator";
-	import {
-		NotificationType,
-		type MediaFragment,
-		type AiringNotification,
-		type RelatedMediaAdditionNotification,
-		type MediaDataChangeNotification,
-	} from "@anilist/graphql";
-	import { hexToRgb } from "$lib/util";
-	import NotificationContainer from "./NotificationContainer.svelte";
+  import { Link } from "svelte-navigator";
+  import { NotificationType, type MediaFragment, type AiringNotification, type RelatedMediaAdditionNotification, type MediaDataChangeNotification } from "@anilist/graphql";
+  import { hexToRgb } from "$lib/util";
+  import NotificationContainer from "./NotificationContainer.svelte";
 
-	export let notification: Pick<
-		| AiringNotification
-		| RelatedMediaAdditionNotification
-		| MediaDataChangeNotification,
-		"createdAt" | "type"
-	> & {
-		context?: string;
-		contexts?: string[];
-		episode?: number;
-		media: Pick<MediaFragment, "id" | "title" | "img">;
-	};
-	export let unread = false;
-
-	let frozenId: number | null = null;
-	$: if (notification?.media && frozenId === null) {
-		frozenId = notification.media.id;
-	}
+  export let notification: 
+  | (Pick<AiringNotification | RelatedMediaAdditionNotification | MediaDataChangeNotification, "createdAt" | "type"> & {
+    context?: string,
+    contexts?: string[],
+    episode?: number,
+    media: Pick<MediaFragment, "id" | "title" | "img">,
+  })
+  | null;
+  export let unread = false;
 </script>
 
-<NotificationContainer {unread} createdAt={notification.createdAt}>
-	{#if frozenId !== null}
-		<Link to={`/media/${frozenId}`} class="flex-none">
-			<img
-				src={notification.media.img?.large || "/placeholder.png"}
-				alt={notification.media.title?.userPreferred || "Media"}
-				class="w-12 mr-4 object-center object-cover aspect-[3/4]"
-			/>
-		</Link>
-
-		<Link
-			to={`/media/${frozenId}`}
-			class="line-clamp-3 mr-6 flex-1"
-			style="--color-variable: {hexToRgb(notification.media.img?.color) ||
-				'var(--color-accent)'}"
-		>
-			{#if notification.type === NotificationType.AIRING}
-				{notification.contexts?.[0] || ""}
-				{notification.episode ?? ""}
-				{notification.contexts?.[1] || ""}
-				<span class="font-medium hover:text-variable transition-colors">
-					{notification.media.title?.userPreferred || "Unknown Title"}
-				</span>
-				{notification.contexts?.[2] || ""}
-			{:else}
-				<span class="font-medium hover:text-variable transition-colors">
-					{notification.media.title?.userPreferred || "Unknown Title"}
-				</span>
-				{notification.context || ""}
-			{/if}
-		</Link>
-	{:else}
-		<div class="flex items-center space-x-4 opacity-50 cursor-not-allowed">
-			<div class="w-12 h-16 bg-gray-200 rounded-md"></div>
-
-			<div class="flex-1 space-y-1">
-				<div class="h-4 bg-gray-200 rounded w-3/4"></div>
-				<div class="h-3 bg-gray-200 rounded w-1/2"></div>
-			</div>
-		</div>
-	{/if}
-</NotificationContainer>
+{#if notification.media}
+  <NotificationContainer {unread} createdAt={notification.createdAt}>
+    <Link to="/media/{notification.media.id}" class="flex-none">
+      <img src={notification.media.img.large} alt="Key visual" class="w-12 mr-4 object-center object-cover aspect-[3/4]" />
+    </Link>
+    <Link to="/media/{notification.media.id}" class="line-clamp-3 mr-6 flex-1" --color-variable={hexToRgb(notification.media.img.color) || "--color-accent"}>
+      {#if notification.type === NotificationType.AIRING}
+        {notification.contexts[0] || ""}
+        {notification.episode || ""}
+        {notification.contexts[1] || ""}
+        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred || ""}</span>
+        {notification.contexts[2] || ""}
+      {:else}
+        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred || ""}</span>
+        {notification.context || ""}
+      {/if}
+    </Link>
+  </NotificationContainer>
+{/if}


### PR DESCRIPTION
I changed the mediaNotification.svelte file to fix null values and prevent those null values from freezing the entire extension. Confirmed to fix the problem in #85 and #87 in both firefox and chromium.