### PR TITLE
Fix notifications tab being blank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animouto",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "animouto",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "1.5.3",

--- a/src/lib/components/notifications/MediaNotification.svelte
+++ b/src/lib/components/notifications/MediaNotification.svelte
@@ -13,20 +13,22 @@
   export let unread = false;
 </script>
 
-<NotificationContainer {unread} createdAt={notification.createdAt}>
-  <Link to="/media/{notification.media.id}" class="flex-none">
-    <img src={notification.media.img.large} alt="Key visual" class="w-12 mr-4 object-center object-cover aspect-[3/4]" />
-  </Link>
-  <Link to="/media/{notification.media.id}" class="line-clamp-3 mr-6 flex-1" --color-variable={hexToRgb(notification.media.img.color) || "--color-accent"}>
-    {#if notification.type === NotificationType.AIRING}
-      {notification.contexts[0]}
-      {notification.episode}
-      {notification.contexts[1]}
-      <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
-      {notification.contexts[2]}
-    {:else}
-      <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
-      {notification.context}
-    {/if}
-  </Link>
-</NotificationContainer>
+{#if notification.media}
+  <NotificationContainer {unread} createdAt={notification.createdAt}>
+    <Link to="/media/{notification.media.id}" class="flex-none">
+      <img src={notification.media.img.large} alt="Key visual" class="w-12 mr-4 object-center object-cover aspect-[3/4]" />
+    </Link>
+    <Link to="/media/{notification.media.id}" class="line-clamp-3 mr-6 flex-1" --color-variable={hexToRgb(notification.media.img.color) || "--color-accent"}>
+      {#if notification.type === NotificationType.AIRING}
+        {notification.contexts[0]}
+        {notification.episode}
+        {notification.contexts[1]}
+        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
+        {notification.contexts[2]}
+      {:else}
+        <span class="font-medium hover:text-variable transition-colors">{notification.media.title.userPreferred}</span>
+        {notification.context}
+      {/if}
+    </Link>
+  </NotificationContainer>
+  {/if}


### PR DESCRIPTION
Fixes an issue where notifications.media wasnt always available and caused the notifications tab to crash. Also bump package-lock.json to match package.json versions. Fixes github issues #85 and #87